### PR TITLE
[#81] workaround

### DIFF
--- a/frontend/src/pages/MaintenancePage/MaintenanceTableDropdown.vue
+++ b/frontend/src/pages/MaintenancePage/MaintenanceTableDropdown.vue
@@ -4,6 +4,7 @@
     bottom
     offset-x
     open-on-hover
+    :open-on-click="false"
     :close-on-content-click="false"
   >
     <template v-slot:activator="{ on }">
@@ -87,6 +88,9 @@ export default {
     doneButtonClicked(mtnId) {
       const selectedChips = this.chipNumberToString();
       this.$emit('doneButtonClicked', mtnId, selectedChips);
+      setTimeout(() => {
+        this.dropdown = false;
+      }, 1);
     },
     chipNumberToString() {
       const selectedChipsArray = [];


### PR DESCRIPTION
vuetify's open-on-hover is triggered in mobile mode
after clicking the button
a timeout of 1 ms closes the dropdown again